### PR TITLE
Add type video to allowed field types

### DIFF
--- a/src/Plugin/MediaEntity/Type/Video.php
+++ b/src/Plugin/MediaEntity/Type/Video.php
@@ -24,7 +24,7 @@ class Video extends MediaTypeBase {
     /** @var \Drupal\media_entity\MediaBundleInterface $bundle */
     $bundle = $form_state->getFormObject()->getEntity();
     $options = [];
-    $allowed_field_types = ['file'];
+    $allowed_field_types = ['file', 'video'];
     foreach ($this->entityFieldManager->getFieldDefinitions('media', $bundle->id()) as $field_name => $field) {
       if (in_array($field->getType(), $allowed_field_types) && !$field->getFieldStorageDefinition()->isBaseField()) {
         $options[$field_name] = $field->getLabel();


### PR DESCRIPTION
Allowing the field type "video" adds support for the Video Module. Worked fine for me when using in with the slick media carousel.